### PR TITLE
Add hover provider for API route detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,30 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "TypeView",
+      "properties": {
+        "typeview.framework": {
+          "type": "string",
+          "enum": [
+            "nextjs-app-router"
+          ],
+          "default": "nextjs-app-router",
+          "description": "Specifies the backend framework used in your project."
+        },
+        "typeview.routeDirectories": {
+          "type": "array",
+          "default": [],
+          "description": "A list of routeDirectories containing API route definitions, relative to the workspace root."
+        }
+      }
+    },
     "commands": [
       {
         "command": "typeview.helloWorld",

--- a/src/resokvers/IRouteResolver.ts
+++ b/src/resokvers/IRouteResolver.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+export interface ResolverConfig {
+    routeDirectoryUris: vscode.Uri[];
+}
+
+export interface IRouteResolver {
+    /**
+     * Name used to identify the resolver.
+     * Must match the value of “framework” in settings.json.
+     */
+    name: string;
+
+    /**
+     * Resolves the file path corresponding to the specified URI.
+     * @param uri URI used in the front end (e.g., ‘/api/users’)
+     * @param config Config generated from user settings
+     * @returns URI of the file path. If not found, undefined.
+     */
+    resolve(uri: string, config: ResolverConfig): Promise<vscode.Uri | undefined>;
+}

--- a/src/resokvers/NextjsAppRouterResolver.ts
+++ b/src/resokvers/NextjsAppRouterResolver.ts
@@ -1,0 +1,34 @@
+// src/resolvers/NextjsAppRouterResolver.ts
+import * as vscode from 'vscode';
+import { IRouteResolver, ResolverConfig } from './IRouteResolver';
+import * as path from 'path';
+
+export class NextjsAppRouterResolver implements IRouteResolver {
+    name = 'nextjs-app-router';
+
+    async resolve(uri: string, config: ResolverConfig): Promise<vscode.Uri | undefined> {
+        
+        if(!uri.startsWith('/api')) {
+            return undefined;
+        }
+
+        const pathWithoutApiPrefix = uri === '/api' ? '' : uri.substring('/api/'.length);
+        const relativePath = path.join(pathWithoutApiPrefix , 'route.ts');
+
+        for (const dirUri of config.routeDirectoryUris) {
+            
+            const fileUri = vscode.Uri.joinPath(dirUri, relativePath);
+
+            try {
+                await vscode.workspace.fs.stat(fileUri);
+
+                console.log(`[${this.name}] Found route file: ${fileUri.fsPath}`);
+                return fileUri;
+            } catch (error) {
+                continue;
+            }
+        }
+
+        return undefined;
+    }
+}


### PR DESCRIPTION
Created a hover action.

- The resolver group solves the problem of converting URIs to directory structures according to the framework.
- extension/findRouteFileForUri calls the framework-compatible resolver.